### PR TITLE
April 2017 event address update

### DIFF
--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -50,7 +50,7 @@
 
           <ul>
             <li>Organizers: Craig Norman <a href="https://twitter.com/@normrider">@normrider</a></li>
-            <li>Meetup URL: <a href="https://ti.to/gasbuddy-regina/nodeschool-regina">https://ti.to/gasbuddy-regina/nodeschool-regina</a>
+            <li>Meetup URL: <a href="https://ti.to/gasbuddy-regina/nodeschool-yqr-nodetrip-to-yxe">https://ti.to/gasbuddy-regina/nodeschool-yqr-nodetrip-to-yxe</a>
           </ul>
 
           <p>If you have questions or feedback about this Code of Conduct please contact one of the organizers.</p>

--- a/register.html
+++ b/register.html
@@ -44,9 +44,9 @@
                       </a>
                     </li>
                     <li>
-                      <a href="https://www.google.ca/maps/place/Innovation+Place/@52.1410383,-106.629213,17z/data=!3m1!4b1!4m5!3m4!1s0x5304f6a4ad311519:0x420813d125cfbbde!8m2!3d52.1410383!4d-106.6270243" target="_blank">
+                      <a href="http://maps.google.com/maps?q=52.1431%2C-106.626+%28Concourse+Building+-+Innovation+Place%2C+Saskatoon+%2C+116+Research+Drive%2C+Saskatoon%29" target="_blank">
                         <i class="fa fa-map-marker"></i>
-                        15 Innovation Blvd #114, Saskatoon SK
+                        Saskatoon SK
                       </a>
                     </li>
                     <li class="event-meta--times"></li>
@@ -60,7 +60,7 @@
                     <p><strong>Where and When</strong> </p>
                     <p>April 1st, 2017</p>
                     <p>1:00 - 4:00 PM</p>
-                    <p>Innovation Place | 15 Innovation Blvd | Saskatoon, SK</p>
+                    <p>Concourse Building - Innovation Place | 116 Research Dr. | Saskatoon, SK</p>
                     <p>Snacks provided</p>
                   </div>
                 </div>


### PR DESCRIPTION
Updating address for the event on registration page.

Also updated Meetup URL on code of conduct page that was pointed to old ti.to page.