### PR TITLE
Remove events content from ReadMe on Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,6 @@ It began in 2013 in Silicon Valley, and has since expanded to become a community
 
 At each workshop, participants will work through interactive tutorials or “workshoppers” that teach programming languages like JavaScript and Node.js. The tutorials are self-guided, but experienced mentors are always on hand to help you through any questions. When you come, you can expect to spend an afternoon with like-minded individuals in the Regina tech community who are there to hang out and learn. Previous coding experience is helpful, but not necessary!
 
-### Past Events
-
-- NodeSchool YQR | Saturday, November 19th, 2016 | 1:00-4:00 PM | The Rotunda at Innovation Place, 10 Research Drive
-- NodeSchool YQR | Saturday, January 14th, 2017 | 1:00-4:00 PM | The Rotunda at Innovation Place, 10 Research Drive
-
-### Upcoming Events
-
-- NODEtrip to YXE | Saturday, April 1st | 1:00 – 4:00 PM | Concourse Building - Innovation Place | 116 Research Dr. | Saskatoon, SK
-
 ### More Info
 
 Please check our page: [https://nodeschool.io/regina-sk](https://nodeschool.io/regina-sk)


### PR DESCRIPTION
This is to avoid frequent updates for events we organize. For more information visitors can checkout website directly.